### PR TITLE
Fixes #7

### DIFF
--- a/autoload/tinygo.vim
+++ b/autoload/tinygo.vim
@@ -38,7 +38,6 @@ function! tinygo#ChangeTinygoTargetTo(target)
             echo "some problem with `tinygo info -target " . a:target . "` execution"
             return
         endif
-
         let $GOROOT = info['goroot']
         let $GOOS = info['goos']
         let $GOARCH = info['goarch']
@@ -48,20 +47,25 @@ function! tinygo#ChangeTinygoTargetTo(target)
     if exists('g:did_coc_loaded')
         " vim/nvim + coc.nvim
         let jsonStr = "{}"
+        let cfg = ".vim/coc-settings.json"
         if isdirectory(".vim")
+            try
+                let lines = readfile(cfg)
+                let jsonStr = join(lines, '')
+                let x = json_decode(jsonStr)
+            catch /.*/
+                let x = {}
+            endtry
+        else "No .vim directory exists
             call mkdir(".vim", "p", 0o700)
-            let cfg = ".vim/coc-settings.json"
-            let lines = readfile(cfg)
-            let jsonStr = join(lines, '')
+            let x = {}
         endif
-        let x = json_decode(jsonStr)
         let x["go.goplsOptions"] = {"env": {
                     \ "GOROOT": $GOROOT,
                     \ "GOOS": $GOOS,
                     \ "GOARCH": $GOARCH,
                     \ "GOFLAGS": $GOFLAGS,
                     \ }}
-
         for key in ['GOROOT', 'GOOS', 'GOARCH', 'GOFLAGS']
             if x["go.goplsOptions"].env[key] == ""
                 unlet x["go.goplsOptions"].env[key]


### PR DESCRIPTION
This commit fixes issue #7 where multiple errors were being thrown when attempting to initialize TinyGo using NeoVim and CoC when no `.vim` directory was present.

The issue was that the `readfile(cfg)` line would throw an error, which wasn't being caught, and then the `x` dict wouldn't be hydrated.

This fix wraps the `readfile` in a `try...catch` and handles the error gracefully.

Tested with NeoVim 0.7.2 and coc.nvim version: 0.0.82-b797c032 on MacOS.